### PR TITLE
Fix C# sample to work

### DIFF
--- a/TestNative/ViewController.cs
+++ b/TestNative/ViewController.cs
@@ -27,7 +27,7 @@ namespace TestNative
             var asset = new AVUrlAsset(
                     NSUrl.FromString(url),
                     new AVUrlAssetOptions(NSDictionary.FromObjectAndKey(
-                                            NSNumber.FromBoolean(true),
+                                            NSNumber.FromInt32(1),
                                             AVUrlAsset.PreferPreciseDurationAndTimingKey)));
             asset.LoadValuesAsynchronously(new string[] { AVASSET_PLAYABLE_KEY }, () => AVAssetLoadComplete(url, asset));
         }


### PR DESCRIPTION
This more closely matches the Swift:
```
        let assetOptions = [AVURLAssetPreferPreciseDurationAndTimingKey : 1]
```

which is a number, not a bool.

You can also just remove the entire section and use:

```
        var asset = new AVUrlAsset(NSUrl.FromString(url), new AVUrlAssetOptions());
```

and that still works.